### PR TITLE
reformat/clean/optimized imports

### DIFF
--- a/fasthigashi/Fast_process.py
+++ b/fasthigashi/Fast_process.py
@@ -1,15 +1,17 @@
 import argparse
-import shutil
+import json
+import math
+import multiprocessing
 import os
-import numpy as np
-import torch
-import torch.nn.functional as F
-from tqdm.auto import tqdm, trange
-from scipy.sparse import csr_matrix, vstack, SparseEfficiencyWarning, diags, \
-	hstack
+import tempfile
 from concurrent.futures import ProcessPoolExecutor, as_completed
-import h5py, math
+
+import numpy as np
 import pandas as pd
+import pybedtools
+import torch
+from scipy.sparse import csr_matrix
+from tqdm.auto import trange
 
 # try:
 # 	get_ipython()
@@ -24,7 +26,6 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 device_ids = [0, 1]
 
 def get_config(config_path = "./config.jSON"):
-	import json
 	c = open(config_path,"r")
 	return json.load(c)
 
@@ -160,7 +161,6 @@ def extract_table(config):
 		input_format = 'higashi_v1'
 	
 	chrom_start_end = np.load(os.path.join(temp_dir, "chrom_start_end.npy"))
-	import multiprocessing
 	cpu_num = multiprocessing.cpu_count()
 	if input_format == 'higashi_v1':
 		print("extracting from data.txt")
@@ -290,7 +290,6 @@ def extract_table(config):
 	
 	
 def remove_blacklist(blacklistbed, chromdf):
-	import pybedtools
 	blacklist = pybedtools.BedTool(blacklistbed)
 	left = chromdf[['chrom1', 'pos1', 'pos1']].copy()
 	left.loc[:, 'temp_indexname'] = np.arange(len(left))
@@ -298,7 +297,6 @@ def remove_blacklist(blacklistbed, chromdf):
 	right = chromdf[['chrom2', 'pos2', 'pos2']].copy()
 	right.loc[:, 'temp_indexname'] = np.arange(len(right))
 
-	import tempfile
 	f1 = tempfile.NamedTemporaryFile()
 	left.to_csv(f1, sep="\t", header=False, index=False)
 	bed_anchor = pybedtools.BedTool(f1.name)

--- a/fasthigashi/parafac2_intergrative.py
+++ b/fasthigashi/parafac2_intergrative.py
@@ -1,9 +1,10 @@
-import gc
-import time
+import multiprocessing as mpl
+
 import torch.cuda
-import torch.jit as jit
+import torch.nn.functional as F
 from opt_einsum import contract
 from sklearn.decomposition import TruncatedSVD
+
 try:
 	from .parafac_integrative import parafac
 	from .project2orthogonal import *
@@ -15,8 +16,7 @@ except:
 	from partial_rwr import partial_rwr, tilte2rec
 	from util import *
 
-import torch.nn.functional as F
-import multiprocessing as mpl
+
 cpu_count = mpl.cpu_count()
 ## factors are named as : U (dim1, dim2, r), A(dim1, r), B(r, r), D(R, r), meta_embedding(dim3, R)
 ## matmul(meta_embedding, D) are also referred to as C

--- a/fasthigashi/parafac_integrative.py
+++ b/fasthigashi/parafac_integrative.py
@@ -1,11 +1,8 @@
-import math, itertools, sys
-from tqdm.auto import tqdm, trange
-
 import numpy as np
-import pandas as pd
-
 import torch
 from opt_einsum import contract
+from tqdm.auto import tqdm, trange
+
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 

--- a/fasthigashi/partial_rwr.py
+++ b/fasthigashi/partial_rwr.py
@@ -1,9 +1,8 @@
 import torch
 import torch.nn.functional as F
-import time
-import numpy as np
+
 torch.backends.cudnn.benchmark = True
-import torch.jit as jit
+
 
 def slice_arrange_func(x, slice_,strips=30):
 	num_bin = int(x.shape[1])

--- a/fasthigashi/project2orthogonal.py
+++ b/fasthigashi/project2orthogonal.py
@@ -1,7 +1,5 @@
 import torch
-import torch.jit as jit
-import numpy as np
-from functools import partial
+
 
 def project2orthogonal(matrix: torch.Tensor, rank:int, compute_device:torch.device):
 	dim_1, dim_2 = matrix.shape[-2], matrix.shape[-1]

--- a/fasthigashi/sparse_for_schic.py
+++ b/fasthigashi/sparse_for_schic.py
@@ -1,12 +1,13 @@
-import copy, time
 import gc
 import math
+import time
+from typing import List
+
 import numpy as np
-from scipy.sparse._sparsetools import coo_tocsr
-from scipy.sparse import coo_matrix, csr_matrix
 import torch
-from typing import Dict, List, Tuple
-from tqdm import tqdm, trange
+from scipy.sparse import coo_matrix, csr_matrix
+from scipy.sparse._sparsetools import coo_tocsr
+
 #TODO: use numpy.unravel_index
 
 gpu_flag = torch.cuda.is_available()
@@ -274,7 +275,7 @@ class Sparse:
 	def numel(self):
 		return int(np.prod(self.shape))
 	
-import torch.jit as jit
+# import torch.jit as jit
 # @jit.script
 def densify_jit(shape:torch.Tensor,
                 indices:List[torch.Tensor],

--- a/fasthigashi/util.py
+++ b/fasthigashi/util.py
@@ -1,12 +1,10 @@
-import math, time, itertools, gc, os, pickle, sys, copy
-import numpy as np, pandas as pd
+import gc
 
+import numpy as np
+import pandas as pd
 import torch
-from tqdm.auto import tqdm, trange
-
-from sklearn.neighbors import NearestNeighbors
-import scipy.sparse
 from scipy.sparse import coo_matrix, csr_matrix
+from tqdm.auto import tqdm
 
 
 def shift_csr(a, u, v, m, n):


### PR DESCRIPTION
# Git Pull Details

### Overview

Hey there, I've made some updates to clean up the codebase. This includes reformatting, optimizing imports, and a few other tweaks.

### Changes

1. **Imports Formatting**: Applied some PEP 8 guidelines for better readability.
2. **Optimized Imports**: Removed unused imports and organized the rest.
3. **Commented Unused Imports**: If there's commented-out code, its imports are now commented out too.
4. **Moved Imports**: Shifted some imports from inside methods to the top of the file.

### Why Imports Shouldn't Be Inside Methods

1. **Performance**: Importing inside a method can slow things down, as the import gets executed each time the method is called.
2. **Readability**: It's easier to understand the code when all imports are at the top.
3. **Debugging**: If an import fails, it's easier to catch the issue when the import is at the top of the file.
4. **Code Reusability**: Imports are more reusable when they're at the top of the file.

### Commented-Out Code

I noticed some parts of the code were commented out but the imports for those sections weren't. To avoid confusion, I've commented out those imports as well.

### Testing

All changes have been tested to ensure existing functionality is unaffected.

---

Feel free to review the changes and let me know if you have any questions or suggestions. Thanks!